### PR TITLE
Фикс важного бага с удалением и возможность настраивать создание превьюшек

### DIFF
--- a/src/FileUploadBehavior.php
+++ b/src/FileUploadBehavior.php
@@ -81,9 +81,10 @@ class FileUploadBehavior extends \yii\base\Behavior
     {
         if ($this->file instanceof UploadedFile) {
             if (!$this->owner->isNewRecord) {
-                /** @var static $oldModel */
+                /** @var ActiveRecord $oldModel */
                 $oldModel = $this->owner->findOne($this->owner->primaryKey);
-                $oldModel->cleanFiles();
+                $behavior = static::getInstance($oldModel, $this->attribute);
+                $behavior->cleanFiles();
             }
             $this->owner->{$this->attribute} = $this->file->baseName . '.' . $this->file->extension;
         } else { // Fix html forms bug, when we have empty file field


### PR DESCRIPTION
Fixed incorrect file deletion when using two and more behaviors with the same model (fixes #5)
Added possibility to customize thumb creation with all features provided by PHPThumb library

Обратная совместимость полная, при создании превьюшек во-первых передаем доп параметры в инстанс GD() (в моем конкретном случае нужно было использовать jpegQuality отличное от 100) и затем даем возможность вызвать любую функцию манипуляции изображением через коллбек.
Нужно только добавить в доку пример как настраивать кастомный ресайз.